### PR TITLE
Integrate HeadDatabase API for pet heads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- HeadDatabase API -->
+        <dependency>
+            <groupId>com.arcaniax</groupId>
+            <artifactId>HeadDatabase-API</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- MythicMobs API -->
         <dependency>
             <groupId>io.lumine</groupId>

--- a/src/main/java/pl/yourserver/ConfigManager.java
+++ b/src/main/java/pl/yourserver/ConfigManager.java
@@ -1,12 +1,15 @@
 package pl.yourserver;
 
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 // import pl.yourserver.petplugin.PetPlugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 public class ConfigManager {
 
@@ -22,6 +25,10 @@ public class ConfigManager {
     private int maxPetsDefault;
     private double followDistance;
     private double teleportDistance;
+
+    // HeadDatabase integration
+    private boolean headDatabaseEnabled;
+    private Map<PetType, String> headDatabaseIds = new EnumMap<>(PetType.class);
 
     // Effect values
     private double cowBonusHealth;
@@ -87,6 +94,14 @@ public class ConfigManager {
         followDistance = config.getDouble("settings.follow-distance", 10.0);
         teleportDistance = config.getDouble("settings.teleport-distance", 20.0);
 
+        headDatabaseEnabled = config.getBoolean("head-database.enabled", true);
+        headDatabaseIds = new EnumMap<>(PetType.class);
+        ConfigurationSection headSection = config.getConfigurationSection("head-database.ids");
+        for (PetType petType : PetType.values()) {
+            String id = headSection != null ? headSection.getString(petType.name(), "") : "";
+            headDatabaseIds.put(petType, id != null ? id : "");
+        }
+
         // All effect values now come from pets.yml, not config.yml
 
         // Boss list
@@ -132,6 +147,14 @@ public class ConfigManager {
 
     public double getTeleportDistance() {
         return teleportDistance;
+    }
+
+    public boolean isHeadDatabaseEnabled() {
+        return headDatabaseEnabled;
+    }
+
+    public String getHeadDatabaseId(PetType petType) {
+        return headDatabaseIds.getOrDefault(petType, "");
     }
 
     public double getCowBonusHealth() {

--- a/src/main/java/pl/yourserver/HeadManager.java
+++ b/src/main/java/pl/yourserver/HeadManager.java
@@ -1,0 +1,100 @@
+package pl.yourserver;
+
+import me.arcaniax.hdb.api.HeadDatabaseAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+public class HeadManager {
+
+    private final PetPlugin plugin;
+    private HeadDatabaseAPI headDatabaseAPI;
+    private final Map<PetType, ItemStack> petHeadCache = new EnumMap<>(PetType.class);
+
+    public HeadManager(PetPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void initialize() {
+        petHeadCache.clear();
+
+        if (!plugin.getConfigManager().isHeadDatabaseEnabled()) {
+            headDatabaseAPI = null;
+            plugin.getLogger().info("HeadDatabase integration disabled in configuration. Using internal textures.");
+            return;
+        }
+
+        Plugin headDatabasePlugin = Bukkit.getPluginManager().getPlugin("HeadDatabase");
+        if (headDatabasePlugin == null) {
+            headDatabaseAPI = null;
+            plugin.getLogger().warning("HeadDatabase plugin not found. Falling back to bundled pet textures.");
+            return;
+        }
+
+        try {
+            String version = headDatabasePlugin.getDescription().getVersion();
+            plugin.getLogger().info("Hooked into HeadDatabase v" + version + "");
+            headDatabaseAPI = new HeadDatabaseAPI();
+        } catch (Throwable throwable) {
+            headDatabaseAPI = null;
+            plugin.getLogger().log(Level.WARNING, "Failed to initialize HeadDatabase API. Falling back to bundled textures.", throwable);
+        }
+    }
+
+    public void reload() {
+        initialize();
+    }
+
+    public boolean isHeadDatabaseAvailable() {
+        return headDatabaseAPI != null;
+    }
+
+    public ItemStack getHeadById(String id) {
+        if (!isHeadDatabaseAvailable() || id == null || id.isEmpty()) {
+            return null;
+        }
+
+        try {
+            ItemStack itemStack = headDatabaseAPI.getItemHead(id);
+            return itemStack != null ? itemStack.clone() : null;
+        } catch (Throwable throwable) {
+            plugin.getLogger().log(Level.WARNING, "Failed to fetch head with id '" + id + "' from HeadDatabase.", throwable);
+            return null;
+        }
+    }
+
+    public ItemStack getPetHead(PetType petType) {
+        if (petType == null) {
+            return new ItemStack(Material.PLAYER_HEAD);
+        }
+        ItemStack cached = petHeadCache.computeIfAbsent(petType, this::loadPetHead);
+        return cached.clone();
+    }
+
+    private ItemStack loadPetHead(PetType petType) {
+        String configuredId = plugin.getConfigManager().getHeadDatabaseId(petType);
+        if (configuredId != null && !configuredId.isEmpty()) {
+            ItemStack apiHead = getHeadById(configuredId);
+            if (apiHead != null) {
+                return apiHead;
+            }
+            plugin.getLogger().warning("HeadDatabase head '" + configuredId + "' for pet " + petType.name() + " could not be loaded. Using fallback texture.");
+        }
+
+        String texture = petType.getSkullTexture();
+        if (texture != null && !texture.isEmpty()) {
+            try {
+                return new ItemBuilder(Material.PLAYER_HEAD).setSkullTexture(texture).build();
+            } catch (Exception exception) {
+                plugin.getLogger().log(Level.WARNING, "Failed to build fallback skull texture for pet " + petType.name() + ".", exception);
+            }
+        }
+
+        return new ItemStack(Material.PLAYER_HEAD);
+    }
+}

--- a/src/main/java/pl/yourserver/InventoryClickListener.java
+++ b/src/main/java/pl/yourserver/InventoryClickListener.java
@@ -266,8 +266,8 @@ public class InventoryClickListener implements Listener {
         lore.add("");
         lore.add(TextUtil.colorize("&eRight-click to use this pet!"));
 
-        ItemStack item = new ItemBuilder(Material.PLAYER_HEAD)
-                .setSkullTexture(pet.getType().getSkullTexture())
+        ItemStack baseHead = plugin.getHeadManager().getPetHead(pet.getType());
+        ItemStack item = (baseHead != null ? new ItemBuilder(baseHead) : new ItemBuilder(Material.PLAYER_HEAD))
                 .setName(TextUtil.colorize(pet.getRarity().getColor() + pet.getType().getDisplayName()))
                 .setLore(lore)
                 .build();

--- a/src/main/java/pl/yourserver/PetBlockListener.java
+++ b/src/main/java/pl/yourserver/PetBlockListener.java
@@ -121,11 +121,10 @@ public class PetBlockListener implements Listener {
         lore.add("");
         lore.add(TextUtil.colorize("&eRight-click to add to your pets!"));
 
-        // Always use player heads with custom textures for all pets
-        ItemStack item = new ItemBuilder(Material.PLAYER_HEAD)
+        ItemStack baseHead = petDropManager.getPlugin().getHeadManager().getPetHead(pet.getType());
+        ItemStack item = (baseHead != null ? new ItemBuilder(baseHead) : new ItemBuilder(Material.PLAYER_HEAD))
                 .setName(TextUtil.colorize(pet.getRarity().getColor() + pet.getType().getDisplayName()))
                 .setLore(lore)
-                .setSkullTexture(pet.getType().getSkullTexture())
                 .build();
 
         // Add NBT data for identification

--- a/src/main/java/pl/yourserver/PetCommand.java
+++ b/src/main/java/pl/yourserver/PetCommand.java
@@ -397,6 +397,7 @@ public class PetCommand implements CommandExecutor, TabCompleter {
         }
 
         plugin.getConfigManager().reload();
+        plugin.getHeadManager().reload();
         sender.sendMessage(TextUtil.colorize("&aConfiguration reloaded!"));
     }
 

--- a/src/main/java/pl/yourserver/PetGUI.java
+++ b/src/main/java/pl/yourserver/PetGUI.java
@@ -164,20 +164,15 @@ public class PetGUI {
             lore.add(TextUtil.colorize("&c⚠ Needs feeding!"));
         }
 
-        // Always use player heads with custom textures for all pets
-        ItemBuilder builder = new ItemBuilder(Material.PLAYER_HEAD)
+        ItemStack baseHead = plugin.getHeadManager().getPetHead(pet.getType());
+        ItemBuilder builder = baseHead != null
+                ? new ItemBuilder(baseHead)
+                : new ItemBuilder(Material.PLAYER_HEAD);
+
+        return builder
                 .setName(TextUtil.colorize(pet.getRarity().getColor() + pet.getType().getDisplayName()))
-                .setLore(lore);
-
-        // Try to set skull texture, fallback to default if it fails
-        try {
-            builder.setSkullTexture(pet.getType().getSkullTexture());
-        } catch (Exception e) {
-            // Fallback to default player head if texture setting fails
-            plugin.getLogger().warning("Failed to set skull texture for pet " + pet.getType().name() + ": " + e.getMessage());
-        }
-
-        return builder.build();
+                .setLore(lore)
+                .build();
     }
 
     // Get appropriate material for pet head as fallback
@@ -268,20 +263,15 @@ public class PetGUI {
             lore.add(TextUtil.colorize("&7Andermant needed: &5" + pet.getRequiredFeedAmount()));
         }
 
-        // Always use player heads with custom textures for all pets
-        ItemBuilder builder = new ItemBuilder(Material.PLAYER_HEAD)
+        ItemStack baseHead = plugin.getHeadManager().getPetHead(pet.getType());
+        ItemBuilder builder = baseHead != null
+                ? new ItemBuilder(baseHead)
+                : new ItemBuilder(Material.PLAYER_HEAD);
+
+        return builder
                 .setName(TextUtil.colorize(pet.getRarity().getColor() + "&l" + pet.getType().getDisplayName()))
-                .setLore(lore);
-
-        // Try to set skull texture, fallback to default if it fails
-        try {
-            builder.setSkullTexture(pet.getType().getSkullTexture());
-        } catch (Exception e) {
-            // Fallback to default player head if texture setting fails
-            plugin.getLogger().warning("Failed to set skull texture for detailed pet " + pet.getType().name() + ": " + e.getMessage());
-        }
-
-        return builder.build();
+                .setLore(lore)
+                .build();
     }
 
     // Stwórz pasek doświadczenia

--- a/src/main/java/pl/yourserver/PetManager.java
+++ b/src/main/java/pl/yourserver/PetManager.java
@@ -228,9 +228,8 @@ public class PetManager {
 
     // Utworz głowę peta
     private ItemStack createPetHead(Pet pet) {
-        return new ItemBuilder(Material.PLAYER_HEAD)
-                .setSkullTexture(pet.getType().getSkullTexture())
-                .build();
+        ItemStack baseHead = plugin.getHeadManager().getPetHead(pet.getType());
+        return baseHead != null ? baseHead : new ItemStack(Material.PLAYER_HEAD);
     }
 
     // Dodaj peta do gracza

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,6 +36,45 @@ settings:
   exp-multiplier: 1.0
 
 # Pet effect settings
+head-database:
+  # Enable integration with the HeadDatabase plugin. When disabled the plugin will use built-in base64 textures.
+  enabled: true
+  # Configure the HeadDatabase ID for each pet (example: "12345" or "MHF_Cow"). Leave empty to use the fallback texture.
+  ids:
+    COW: ""
+    PIG: ""
+    SHEEP: ""
+    CHICKEN: ""
+    DONKEY: ""
+    SNOW_GOLEM: ""
+    IRON_GOLEM: ""
+    SQUID: ""
+    TURTLE: ""
+    LLAMA: ""
+    ENDERMAN: ""
+    WITCH: ""
+    HUSK: ""
+    MOOSHROOM: ""
+    FROG: ""
+    WOLF: ""
+    BEE: ""
+    WANDERING_TRADER: ""
+    PANDA: ""
+    ZOMBIE: ""
+    SKELETON: ""
+    SPIDER: ""
+    CREEPER: ""
+    SLIME: ""
+    PHANTOM: ""
+    GLOW_SQUID: ""
+    GUARDIAN: ""
+    SNIFFER: ""
+    WITHER_SKELETON: ""
+    ENDER_DRAGON: ""
+    WARDEN: ""
+    WITHER: ""
+    GIANT: ""
+
 effects:
   # Effect tick rate (in ticks, 20 = 1 second)
   tick-rate: 20


### PR DESCRIPTION
## Summary
- add a dedicated HeadManager that hooks into HeadDatabase 4.21.x while caching fallback textures
- update all pet head generation code paths to use the manager instead of raw base64 handling
- expose configuration for per-pet HeadDatabase IDs and reload the integration alongside the configs

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68d3997c0bfc832aa167ed0ea02e9a39