### PR TITLE
Prevent hostile pet aggression

### DIFF
--- a/src/main/java/pl/yourserver/EntityDamageListener.java
+++ b/src/main/java/pl/yourserver/EntityDamageListener.java
@@ -56,15 +56,22 @@ public class EntityDamageListener implements Listener {
             return;
         }
 
+        // Prevent pets from damaging anything
+        Entity damager = event.getDamager();
+        if (damager.hasMetadata("pet")) {
+            event.setCancelled(true);
+            return;
+        }
+
         // Sprawdź czy atakujący to gracz
-        if (event.getDamager() instanceof Player) {
-            Player attacker = (Player) event.getDamager();
+        if (damager instanceof Player) {
+            Player attacker = (Player) damager;
             handlePlayerAttack(attacker, event);
         }
 
         // Sprawdź czy obrońca to gracz
-        if (event.getEntity() instanceof Player) {
-            Player defender = (Player) event.getEntity();
+        if (entity instanceof Player) {
+            Player defender = (Player) entity;
             handlePlayerDefense(defender, event);
         }
     }

--- a/src/main/java/pl/yourserver/PetFollowTask.java
+++ b/src/main/java/pl/yourserver/PetFollowTask.java
@@ -50,6 +50,13 @@ public class PetFollowTask extends BukkitRunnable {
                 Location playerLoc = player.getLocation();
                 Location petLoc = entity.getLocation();
 
+                if (entity instanceof Mob) {
+                    Mob mob = (Mob) entity;
+                    if (mob.getTarget() != null) {
+                        mob.setTarget(null);
+                    }
+                }
+
                 double distance = playerLoc.distance(petLoc);
                 double followDistance = plugin.getConfigManager().getFollowDistance();
                 double teleportDistance = plugin.getConfigManager().getTeleportDistance();

--- a/src/main/java/pl/yourserver/PetPlugin.java
+++ b/src/main/java/pl/yourserver/PetPlugin.java
@@ -120,6 +120,7 @@ public class PetPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PetInteractListener(this), this);
         getServer().getPluginManager().registerEvents(new InventoryClickListener(this), this);
         getServer().getPluginManager().registerEvents(new EntityDamageListener(this), this);
+        getServer().getPluginManager().registerEvents(new PetTargetListener(), this);
         getServer().getPluginManager().registerEvents(petMoneyManager, this);
         getServer().getPluginManager().registerEvents(petInventoryManager, this);
         getServer().getPluginManager().registerEvents(petCombatManager, this);
@@ -141,6 +142,9 @@ public class PetPlugin extends JavaPlugin {
 
         // Task do aur petów (co 3 sekundy = 60 ticków)
         petAuraManager.runTaskTimer(this, 0L, 60L);
+
+        // Task dbający o bezpieczeństwo graczy przy agresywnych petach
+        new PetSafetyTask(this).runTaskTimer(this, 0L, 20L);
     }
 
     public static PetPlugin getInstance() {

--- a/src/main/java/pl/yourserver/PetSafetyTask.java
+++ b/src/main/java/pl/yourserver/PetSafetyTask.java
@@ -1,0 +1,56 @@
+package pl.yourserver;
+
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.List;
+
+public class PetSafetyTask extends BukkitRunnable {
+
+    private static final double WARDEN_CLEANSE_RADIUS = 20.0;
+
+    private final PetPlugin plugin;
+
+    public PetSafetyTask(PetPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void run() {
+        for (Player player : plugin.getServer().getOnlinePlayers()) {
+            List<Pet> pets = plugin.getPetManager().getActivePets(player);
+            if (pets.isEmpty()) {
+                continue;
+            }
+
+            for (Pet pet : pets) {
+                // Ensure hostile mobs never keep a combat target
+                if (pet.getEntity() instanceof org.bukkit.entity.Mob) {
+                    org.bukkit.entity.Mob mob = (org.bukkit.entity.Mob) pet.getEntity();
+                    if (mob.getTarget() != null) {
+                        mob.setTarget(null);
+                    }
+                }
+
+                if (pet.getType() != PetType.WARDEN) {
+                    continue;
+                }
+
+                if (pet.getEntity() == null || pet.getEntity().isDead()) {
+                    continue;
+                }
+
+                pet.getEntity().getWorld().getNearbyPlayers(pet.getEntity().getLocation(), WARDEN_CLEANSE_RADIUS)
+                        .forEach(nearby -> {
+                            if (nearby.hasPotionEffect(PotionEffectType.DARKNESS)) {
+                                nearby.removePotionEffect(PotionEffectType.DARKNESS);
+                            }
+                            if (nearby.hasPotionEffect(PotionEffectType.BLINDNESS)) {
+                                nearby.removePotionEffect(PotionEffectType.BLINDNESS);
+                            }
+                        });
+            }
+        }
+    }
+}

--- a/src/main/java/pl/yourserver/PetTargetListener.java
+++ b/src/main/java/pl/yourserver/PetTargetListener.java
@@ -1,0 +1,35 @@
+package pl.yourserver;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Mob;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityTargetEvent;
+
+public class PetTargetListener implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEntityTarget(EntityTargetEvent event) {
+        Entity entity = event.getEntity();
+
+        if (entity.hasMetadata("pet")) {
+            if (entity instanceof Mob) {
+                ((Mob) entity).setTarget(null);
+            }
+            event.setCancelled(true);
+            event.setTarget(null);
+            return;
+        }
+
+        Entity target = event.getTarget();
+        if (target != null && target.hasMetadata("pet")) {
+            event.setCancelled(true);
+            event.setTarget(null);
+
+            if (entity instanceof Mob) {
+                ((Mob) entity).setTarget(null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure pet entities never damage players by cancelling their outgoing attacks
- cancel target acquisition on pet entities and clear hostile potion effects near warden pets
- register new safety listener/task and keep clearing mob targets while they follow their owners

## Testing
- `mvn -q -DskipTests package` *(fails: Maven cannot reach central repository in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bf4efed4832abc2c115f1618a715