### PR TITLE
Fix multi-pet entity overlap and adjust Ender Dragon duplication

### DIFF
--- a/src/main/java/pl/yourserver/PetEffectManager.java
+++ b/src/main/java/pl/yourserver/PetEffectManager.java
@@ -316,7 +316,7 @@ public class PetEffectManager {
                 // Duplikacja efektu drugiego peta
                 List<Pet> activePets = plugin.getPetManager().getActivePets(player);
                 for (Pet otherPet : activePets) {
-                    if (otherPet != pet && otherPet.getType() != PetType.ENDER_DRAGON) {
+                    if (otherPet != pet && otherPet.getType() != PetType.ENDER_DRAGON && otherPet.getType() != PetType.WARDEN) {
                         applyPetEffect(player, otherPet); // Duplikuj efekt
 
                         // Specjalny efekt na 100lvl: podwÄ‚â€žĂ˘â‚¬ĹˇĂ„Ä…Ă˘â‚¬Ĺˇjna duplikacja

--- a/src/main/java/pl/yourserver/PetFollowTask.java
+++ b/src/main/java/pl/yourserver/PetFollowTask.java
@@ -78,7 +78,7 @@ public class PetFollowTask extends BukkitRunnable {
                     stuckTicks.remove(pet.getUuid());
                 }
 
-                Location targetLoc = getOffsetLocation(player, petIndex, petCount);
+                Location targetLoc = calculateOffsetLocation(player, petIndex, petCount);
 
                 boolean shouldTeleport = distance > teleportDistance
                         && stuckTicks.getOrDefault(pet.getUuid(), 0) >= STUCK_TICK_THRESHOLD;
@@ -151,7 +151,7 @@ public class PetFollowTask extends BukkitRunnable {
         }
     }
 
-    private Location getOffsetLocation(Player player, int index, int totalPets) {
+    public Location calculateOffsetLocation(Player player, int index, int totalPets) {
         Location loc = player.getLocation();
 
         // Offset different pet counts for nicer positioning


### PR DESCRIPTION
## Summary
- allow multiple active pets to remain spawned simultaneously by despawning entities per-pet and reusing follow offsets for their initial spawn location
- expose the follow task's offset calculation so pets spawn at their expected positions instead of stacking
- prevent the Ender Dragon duplication effect from duplicating the Warden's pet slot bonus

## Testing
- mvn -q -DskipTests package *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d413b3a954832a82d010ece996c379