### PR TITLE
Add donkey backpack shortcut to pet GUI

### DIFF
--- a/src/main/java/pl/yourserver/InventoryClickListener.java
+++ b/src/main/java/pl/yourserver/InventoryClickListener.java
@@ -117,6 +117,13 @@ public class InventoryClickListener implements Listener {
             return;
         }
 
+        // Otwieranie plecaka Donkey (slot 4)
+        if (pet.getType() == PetType.DONKEY && slot == 4 && clicked.getType() == Material.CHEST) {
+            plugin.getPetInventoryManager().openDonkeyInventory(player);
+            player.playSound(player.getLocation(), Sound.BLOCK_CHEST_OPEN, 1.0f, 1.0f);
+            return;
+        }
+
         // Aktywacja/Deaktywacja peta (slot 29)
         if (slot == 29) {
             plugin.getPetManager().togglePet(player, pet);

--- a/src/main/java/pl/yourserver/PetGUI.java
+++ b/src/main/java/pl/yourserver/PetGUI.java
@@ -91,6 +91,17 @@ public class PetGUI {
         ItemStack petInfo = createDetailedPetItem(pet);
         gui.setItem(13, petInfo);
 
+        // Donkey backpack shortcut (slot 4 - above pet info)
+        if (pet.getType() == PetType.DONKEY) {
+            ItemStack backpackShortcut = new ItemBuilder(Material.CHEST)
+                    .setName(TextUtil.colorize("&6Open Donkey Backpack"))
+                    .addLore(TextUtil.colorize("&7Access the storage of your Donkey pet."))
+                    .addLore("")
+                    .addLore(TextUtil.colorize("&eClick to open &7(/donkey)"))
+                    .build();
+            gui.setItem(4, backpackShortcut);
+        }
+
         // Przycisk aktywacji/deaktywacji
         Material toggleMaterial = pet.isActive() ? Material.ENDER_PEARL : Material.EMERALD;
         String toggleName = pet.isActive() ? "&5Deactivate Pet" : "&aActivate Pet";


### PR DESCRIPTION
## Summary
- add a donkey-specific shortcut button in the pet menu to access the backpack
- handle clicks on the shortcut to open the donkey storage with audio feedback

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68da72fbef98832aa6d3b36bd4fae73c