### PR TITLE
Fix donkey backpack slot scaling and shortcut

### DIFF
--- a/src/main/java/pl/yourserver/DatabaseManager.java
+++ b/src/main/java/pl/yourserver/DatabaseManager.java
@@ -313,10 +313,11 @@ public class DatabaseManager {
             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
 
             int size = dataInput.readInt();
-            Inventory inventory = Bukkit.createInventory(null, slots, TextUtil.colorize("&5Donkey Storage"));
+            int normalizedSize = Math.max(slots, size);
+            Inventory inventory = Bukkit.createInventory(null, normalizedSize, TextUtil.colorize("&5Donkey Storage"));
 
             // Wczytaj wszystkie itemy
-            for (int i = 0; i < size && i < slots; i++) {
+            for (int i = 0; i < size && i < inventory.getSize(); i++) {
                 ItemStack item = (ItemStack) dataInput.readObject();
                 if (item != null) {
                     inventory.setItem(i, item);
@@ -339,10 +340,10 @@ public class DatabaseManager {
     }
 
     // Wczytaj backpack z bazy danych
-    public Inventory loadBackpackInventory(UUID playerUUID) {
+    public Inventory loadBackpackInventory(UUID playerUUID, int preferredSlots) {
         String data = loadBackpack(playerUUID);
         if (data != null && !data.isEmpty()) {
-            return deserializeInventory(data, 27); // Domyślnie 27 slotów
+            return deserializeInventory(data, preferredSlots);
         }
         return null;
     }

--- a/src/main/java/pl/yourserver/DonkeyBackpackUtil.java
+++ b/src/main/java/pl/yourserver/DonkeyBackpackUtil.java
@@ -1,0 +1,32 @@
+package pl.yourserver;
+
+/**
+ * Utility helpers for handling donkey backpack slot progression.
+ */
+public final class DonkeyBackpackUtil {
+
+    public static final int BASE_SLOTS = 9;
+    public static final int MID_SLOTS = 18;
+    public static final int MAX_SLOTS = 27;
+    private static final int MID_LEVEL_THRESHOLD = 20;
+
+    private DonkeyBackpackUtil() {
+    }
+
+    public static int resolveSlots(Pet pet) {
+        if (pet == null || pet.getType() != PetType.DONKEY) {
+            return BASE_SLOTS;
+        }
+        return resolveSlots(pet.getLevel(), pet.getType().getDefaultRarity().getMaxLevel());
+    }
+
+    public static int resolveSlots(int petLevel, int maxLevel) {
+        if (petLevel >= maxLevel) {
+            return MAX_SLOTS;
+        }
+        if (petLevel >= MID_LEVEL_THRESHOLD) {
+            return MID_SLOTS;
+        }
+        return BASE_SLOTS;
+    }
+}

--- a/src/main/java/pl/yourserver/InventoryClickListener.java
+++ b/src/main/java/pl/yourserver/InventoryClickListener.java
@@ -117,6 +117,13 @@ public class InventoryClickListener implements Listener {
             return;
         }
 
+        // Otwieranie plecaka Donkey (slot 4)
+        if (pet.getType() == PetType.DONKEY && slot == 4 && clicked.getType() == Material.CHEST) {
+            plugin.getPetInventoryManager().openDonkeyInventory(player);
+            player.playSound(player.getLocation(), Sound.BLOCK_CHEST_OPEN, 1.0f, 1.0f);
+            return;
+        }
+
         // Aktywacja/Deaktywacja peta (slot 29)
         if (slot == 29) {
             plugin.getPetManager().togglePet(player, pet);

--- a/src/main/java/pl/yourserver/PetEffectManager.java
+++ b/src/main/java/pl/yourserver/PetEffectManager.java
@@ -70,8 +70,8 @@ public class PetEffectManager {
                 break;
 
             case DONKEY:
-                // Dodatkowy schowek: 9 slotÄ‚â€žĂ˘â‚¬ĹˇĂ„Ä…Ă˘â‚¬Ĺˇw Ă„â€šĂ‹ÂÄ‚ËĂ˘â€šÂ¬Ă‚Â Ä‚ËĂ˘â€šÂ¬Ă˘â€žË 27 na 25lvl
-                int extraSlots = pet.getLevel() >= 25 ? 27 : 9;
+                // Dodatkowy schowek: 9 slotów, 18 na średnich poziomach, 27 na maksymalnym poziomie
+                int extraSlots = DonkeyBackpackUtil.resolveSlots(pet);
                 integrations.setPlaceholder("donkey_extra_storage", extraSlots);
                 break;
 

--- a/src/main/java/pl/yourserver/PetGUI.java
+++ b/src/main/java/pl/yourserver/PetGUI.java
@@ -91,6 +91,17 @@ public class PetGUI {
         ItemStack petInfo = createDetailedPetItem(pet);
         gui.setItem(13, petInfo);
 
+        // Donkey backpack shortcut (slot 4 - above pet info)
+        if (pet.getType() == PetType.DONKEY) {
+            ItemStack backpackShortcut = new ItemBuilder(Material.CHEST)
+                    .setName(TextUtil.colorize("&6Open Donkey Backpack"))
+                    .addLore(TextUtil.colorize("&7Access the storage of your Donkey pet."))
+                    .addLore("")
+                    .addLore(TextUtil.colorize("&eClick to open &7(/donkey)"))
+                    .build();
+            gui.setItem(4, backpackShortcut);
+        }
+
         // Przycisk aktywacji/deaktywacji
         Material toggleMaterial = pet.isActive() ? Material.ENDER_PEARL : Material.EMERALD;
         String toggleName = pet.isActive() ? "&5Deactivate Pet" : "&aActivate Pet";

--- a/src/main/java/pl/yourserver/PetInventoryManager.java
+++ b/src/main/java/pl/yourserver/PetInventoryManager.java
@@ -1,7 +1,7 @@
 package pl.yourserver;
 
-import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -11,7 +11,9 @@ import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -32,20 +34,23 @@ public class PetInventoryManager implements Listener {
             return;
         }
 
-        // Pobierz liczbę slotów z PlaceholderAPI
-        String slotsStr = PlaceholderAPI.setPlaceholders(player, "%petplugin_donkey_extra_storage%");
-        int slots;
-        try {
-            slots = Integer.parseInt(slotsStr);
-        } catch (NumberFormatException e) {
-            slots = 9; // Domyślnie 9 slotów
-        }
+        // Pobierz aktywnego osła i wylicz sloty
+        Pet activeDonkey = getActiveDonkey(player);
+        int slots = DonkeyBackpackUtil.resolveSlots(activeDonkey);
 
         // Stwórz lub pobierz istniejący backpack
         Inventory backpack = playerBackpacks.get(player.getUniqueId());
         if (backpack == null) {
-            backpack = Bukkit.createInventory(null, slots,
-                TextUtil.colorize("&5Donkey Storage &7(" + slots + " slots)"));
+            Inventory loaded = plugin.getDatabaseManager()
+                    .loadBackpackInventory(player.getUniqueId(), slots);
+            if (loaded != null) {
+                backpack = resizeBackpack(loaded, slots, player);
+            } else {
+                backpack = createBackpack(slots);
+            }
+            playerBackpacks.put(player.getUniqueId(), backpack);
+        } else if (backpack.getSize() != slots) {
+            backpack = resizeBackpack(backpack, slots, player);
             playerBackpacks.put(player.getUniqueId(), backpack);
         }
 
@@ -104,9 +109,86 @@ public class PetInventoryManager implements Listener {
     }
 
     public void loadPlayerBackpack(Player player) {
-        Inventory backpack = plugin.getDatabaseManager().loadBackpackInventory(player.getUniqueId());
-        if (backpack != null) {
-            playerBackpacks.put(player.getUniqueId(), backpack);
+        Pet donkey = getHighestLevelDonkey(player);
+        if (donkey == null) {
+            return;
         }
+
+        int slots = DonkeyBackpackUtil.resolveSlots(donkey);
+        Inventory backpack = plugin.getDatabaseManager()
+                .loadBackpackInventory(player.getUniqueId(), slots);
+        if (backpack != null) {
+            Inventory adjusted = resizeBackpack(backpack, slots, player);
+            playerBackpacks.put(player.getUniqueId(), adjusted);
+        }
+    }
+
+    private Pet getActiveDonkey(Player player) {
+        for (Pet pet : plugin.getPetManager().getActivePets(player)) {
+            if (pet.getType() == PetType.DONKEY && pet.isActive()) {
+                return pet;
+            }
+        }
+        return getHighestLevelDonkey(player);
+    }
+
+    private Pet getHighestLevelDonkey(Player player) {
+        Pet highest = null;
+        for (Pet pet : plugin.getPetManager().getPlayerPets(player)) {
+            if (pet.getType() != PetType.DONKEY) {
+                continue;
+            }
+            if (highest == null || pet.getLevel() > highest.getLevel()) {
+                highest = pet;
+            }
+        }
+        return highest;
+    }
+
+    private Inventory createBackpack(int slots) {
+        return Bukkit.createInventory(null, slots,
+                TextUtil.colorize("&5Donkey Storage &7(" + slots + " slots)"));
+    }
+
+    private Inventory resizeBackpack(Inventory original, int targetSlots, Player player) {
+        if (original == null) {
+            return createBackpack(targetSlots);
+        }
+
+        Inventory resized = createBackpack(targetSlots);
+        int copyLimit = Math.min(original.getSize(), targetSlots);
+        for (int i = 0; i < copyLimit; i++) {
+            ItemStack item = original.getItem(i);
+            if (item != null && item.getType() != Material.AIR) {
+                resized.setItem(i, item.clone());
+            }
+        }
+
+        if (original.getSize() > targetSlots) {
+            List<ItemStack> overflow = new ArrayList<>();
+            for (int i = targetSlots; i < original.getSize(); i++) {
+                ItemStack item = original.getItem(i);
+                if (item != null && item.getType() != Material.AIR) {
+                    overflow.add(item.clone());
+                }
+            }
+            handleOverflow(player, overflow);
+        }
+
+        return resized;
+    }
+
+    private void handleOverflow(Player player, List<ItemStack> overflow) {
+        if (overflow.isEmpty()) {
+            return;
+        }
+
+        Map<Integer, ItemStack> leftovers = player.getInventory()
+                .addItem(overflow.toArray(new ItemStack[0]));
+        leftovers.values().forEach(item ->
+                player.getWorld().dropItemNaturally(player.getLocation(), item));
+
+        player.sendMessage(TextUtil.colorize(plugin.getConfigManager().getPrefix()
+                + "&eYour donkey backpack was resized. Extra items were moved to your inventory or dropped at your feet."));
     }
 }

--- a/src/main/java/pl/yourserver/PetPlaceholderExpansion.java
+++ b/src/main/java/pl/yourserver/PetPlaceholderExpansion.java
@@ -244,7 +244,7 @@ public class PetPlaceholderExpansion extends PlaceholderExpansion {
     private int getDonkeyStorage(List<Pet> pets) {
         for (Pet pet : pets) {
             if (pet.getType() == PetType.DONKEY) {
-                return pet.getLevel() >= 25 ? 27 : 9;
+                return DonkeyBackpackUtil.resolveSlots(pet);
             }
         }
         return 0;

--- a/src/main/resources/pets.yml
+++ b/src/main/resources/pets.yml
@@ -92,9 +92,10 @@ pets:
     effects:
       extra-inventory:
         base-slots: 9
-        level-25-slots: 27
+        mid-level-slots: 18
+        max-level-slots: 27
         description: "Extra inventory (%value% slots)"
-        # Lvl 1-24: 9 slots, Lvl 25+: 27 slots
+        # Lvl 1-19: 9 slots, Lvl 20-39: 18 slots, Lvl 40: 27 slots
     placeholders:
       - "pet_donkey_extra_storage"
 


### PR DESCRIPTION
## Summary
- add a donkey-specific shortcut button in the pet menu to access the backpack
- handle clicks on the shortcut to open the donkey storage with audio feedback
- restore donkey backpack slot progression (9/18/27) and resize saved inventories safely

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68da72fbef98832aa6d3b36bd4fae73c